### PR TITLE
Adding .env support and fixing webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 package-lock.json
 *bundle.js
 *.map
+
+.env

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ### Setup
 
  - `npm install`
+ - Copy `example.env` to `.env` in the root directory
+   - Replace `API_KEY` with a personal github API token
  - `npm run build`
  - `npm start`
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,8 @@
+# Copy this file into a file called env
+# Make sure to reassign API_KEY otherwise no api calls will work
+
+# Port used by the express server
+PORT=3000
+
+# API key used to access FEC database server
+API_KEY="INSERT API KEY HERE"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-react": "^7.16.7",
     "axios": "^0.26.1",
     "babel-loader": "^8.2.4",
-    "dot-env": "^0.0.1",
+    "dotenv": "^16.0.0",
     "express": "^4.17.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-react": "^7.16.7",
     "axios": "^0.26.1",
     "babel-loader": "^8.2.4",
+    "dot-env": "^0.0.1",
     "express": "^4.17.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,9 +1,11 @@
+require('dotenv').config();
+
 const express = require('express');
 const path = require('path');
 
 const app = express();
 
-const port = 3000;
+const port = process.env.PORT;
 
 app.use(express.static(path.join(__dirname, '../client/dist')));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,4 +19,7 @@ module.exports = {
       },
     ],
   },
+  resolve: {
+    extensions: ['*', '.js', '.jsx'],
+  },
 };


### PR DESCRIPTION
## Adding env support
94e09e58995635ad999f6a469f1a2090635c2924 86e108ae999e46b57a30d7dfabfcb6a25eb00f3e 215e5014dfc16047a55bdf5bbd555e4bf4f0c516 7010f111306a5107d9265660c0a0cca96b35136b 85978d8f9f978edfa0d8086e4068a73c79e189bd

In these commits I added the example.env file, as well as installed the correct npm package `dotenv` to allow for use of environment variables.

This will aid in both future deployment and allowing us to use secure tokens.

## Webpack
910b2b226b5bc02a6fd57a2076ad0bccde1243ca

I added the resolve field in the webpack config, as the AirBnB style guide requires no file extensions in imports, which means we have to make sure webpack actually parses the .jsx files