### PR TITLE
Adding stars and relaxing eslint constraints

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,8 +21,11 @@ module.exports = {
   },
   plugins: [
     'react',
+    'better-styled-components',
   ],
   rules: {
     'no-console': 0,
+    'react/no-array-index-key': 0,
+    'react/forbid-prop-types': [2, { forbid: ['any'] }],
   },
 };

--- a/client/src/components/common/Stars.jsx
+++ b/client/src/components/common/Stars.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styled from 'styled-components';
+
+const StarContainer = styled.div`
+  font-size: 1.5rem;
+  display: flex;
+`;
+
+const EmptyStar = styled.div`
+  line-height: 1em;
+`;
+
+const FullStar = styled(EmptyStar)`
+  position: relative;
+  top: -1em;
+  width: ${({ fill }) => Math.round((fill * 100) / 25) * 25}%;
+  overflow: hidden;
+`;
+
+function Star({ fill }) {
+  return (
+    <div>
+      <EmptyStar>☆</EmptyStar>
+      <FullStar fill={fill}>★</FullStar>
+    </div>
+  );
+}
+
+export default function Stars({ stars }) {
+  const starsArray = Array(5).fill(0);
+  let starsRemaining = stars;
+
+  for (let i = 0; starsRemaining > 0; i += 1) {
+    starsArray[i] = Math.min(starsRemaining, 1);
+    starsRemaining -= 1;
+  }
+
+  return (
+    <StarContainer>
+      {starsArray.map((fill, key) => <Star key={`star ${key}`} fill={fill} />)}
+    </StarContainer>
+  );
+}
+
+Stars.propTypes = {
+  stars: PropTypes.number.isRequired,
+};
+
+Star.propTypes = {
+  fill: PropTypes.number.isRequired,
+};


### PR DESCRIPTION
## Stars
f31f5edcaec7c4dabbb252eda5a89ab7cc6e1915
 - Stars.jsx added in the components/common directory
   - To use, just import the default component `import Stars from './common/Stars'
   - Simply create a stars component and pass in the number of stars
   `<Stars stars={3.5} />`
  
## Eslint
400aff80c6a72ba16dbdc4e7629a35d8dd63d20c
 - Two rules added
   - `react/no-array-index-key = 0` disable the rule preventing use array index as a key for lists of items
     - This is because stars arent unique, and only identifiable by their number
   - `react/forbid-prop-types` This rule prevents generic prop types
     - I relaxed this rule to only prevent the proptype `any` but still allow `object` and `array`